### PR TITLE
Fix tid not found error

### DIFF
--- a/src/enif_protobuf.erl
+++ b/src/enif_protobuf.erl
@@ -29,8 +29,8 @@ init() ->
         Path ->
             Path
     end,
-    Processors = erlang:system_info(logical_processors),
-    ok = erlang:load_nif(filename:join(PrivDir, "enif_protobuf"), Processors).
+    Threads = erlang:system_info(schedulers),
+    ok = erlang:load_nif(filename:join(PrivDir, "enif_protobuf"), Threads).
 
 not_loaded(Line) ->
     erlang:nif_error({not_loaded, [{module, ?MODULE}, {line, Line}]}).

--- a/test/ep_tests.erl
+++ b/test/ep_tests.erl
@@ -149,7 +149,7 @@ loop_decoding(N) ->
             ignore
     end,
     decoding(),
-    loop_encoding(N - 1).
+    loop_decoding(N - 1).
 
 smp_cache_decoding_test_() ->
     rand:uniform(),


### PR DESCRIPTION
Hi,

this pr solves #8. As discussed in issue, I have replaced `erlang:system_info(logical_processors)` with `erlang:system_info(schedulers)` and clear locks when `tid` change. To avoid races it is not enough to just wait for `state->cache_lock` but also threads waiting for rlock on `cache_lock` needs to check that locks were not cleared during their waiting hence checking `lock->tid`.

For testing nif changes I have returned to using `erlang:system_info(logical_processors)`, added checks for return value from `encoding()`/`decoding()` and run unit tests with `+S32:32` (my cpu has 8 logic cores). 
Same tests fails on master with `{error, tid_not_found}`.

I have opened pr to solve eventual reservations about the code but I will yet conduct more tests.