### PR TITLE
Fix load_cache segfaults issue [#31]

### DIFF
--- a/c_src/ep_node.c
+++ b/c_src/ep_node.c
@@ -756,6 +756,12 @@ stack_ensure_all(ErlNifEnv *env, ep_cache_t *cache)
                     continue;
                 }
 
+                // skip over enums - they can't be nested
+                if (spot->node->n_type == node_enum) {
+                    spot->pos = spot->node->size;
+                    continue;
+                }
+
                 for (j = spot->pos; j < (size_t) (spot->node->size); j++) {
                     spot->pos = j + 1;
                     field = ((ep_field_t *) (spot->node->fields)) + j;

--- a/test/ep_issue_31_tests.erl
+++ b/test/ep_issue_31_tests.erl
@@ -1,0 +1,23 @@
+%% Copyright (c) jg_513@163.com, https://github.com/jg513
+
+-module(ep_issue_31_tests).
+
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("gpb/include/gpb.hrl").
+
+
+% https://github.com/jg513/enif_protobuf/issues/31
+issue_31_test() ->
+    Defs = [
+        {{enum, very_long}, defs_enum_gen(100000, [])}
+    ],
+
+    enif_protobuf:purge_cache(),
+    enif_protobuf:load_cache(Defs).
+
+defs_enum_gen(0, OptList) -> OptList;
+defs_enum_gen(N, CurOptList) when N > 0 ->
+    defs_enum_gen(N-1, [{list_to_atom("opt" ++ integer_to_list(N)), N} | CurOptList]).
+


### PR DESCRIPTION
This diff fixes the issue with random segfaults in load_cache_1: https://github.com/jg513/enif_protobuf/issues/31

The current `stack_ensure_all()` casts `spot->node->fields` to  `ep_field_t` to iterate through a given node's fields, but these nodes can also be enums with fields of  type `ep_enum_field_t` which is significantly smaller. This mismatch leads to quickly going past the end of every enum node's `fields` array, and `field->o_type` starts to index into other memory.

This usually doesn't lead to segfaults because the allocated memory for the nif state is so large that these accesses rarely go past it, so the program just silently loops through all the enums without doing anything other than access random parts of the state. This is also why the test I've added creates such a large enum, and why the issue #31 is both hard to reproduce and only happening on larger, more involved projects. 

This diff fixes the issue by simply skipping enums in `stack_ensure_all()`, as they have to contain integer fields so there's no need to check for nested messages or maps or anything. 