### PR TITLE
Always select zero field for the default enum value

### DIFF
--- a/c_src/ep_decoder.c
+++ b/c_src/ep_decoder.c
@@ -866,7 +866,11 @@ fill_default(ErlNifEnv *env, ep_spot_t *spot)
             }
 
             case field_enum: {
-                *t++ = ((ep_enum_field_t *) field->sub_node->fields)->name;
+                ep_enum_field_t* efield = field->sub_node->v_fields;
+                int32_t target = 0;
+                ep_enum_field_t* zfield=bsearch(&target, efield, field->sub_node->v_size, sizeof(ep_enum_field_t), get_enum_compare_value);
+                if(zfield) *t++ = zfield->name;
+                else *t++ = ((ep_enum_field_t*)field->sub_node->fields)->name;
                 break;
             }
 

--- a/test/ep_issue_enum_decoding_tests.erl
+++ b/test/ep_issue_enum_decoding_tests.erl
@@ -1,0 +1,17 @@
+-module(ep_issue_enum_decoding_tests).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("gpb/include/gpb.hrl").
+
+
+issue_enum_decoding_test() ->
+    PAtom = pre_existing_atom,
+    Defs = [{syntax, "proto3"},
+        {proto3_msgs, [enum_with_default]},
+        {{enum, en}, [{zzz, 0}, {PAtom, 1}, {nval, -1}]},
+        {{msg, enum_with_default}, [#?gpb_field{name = a, fnum = 1, rnum = 2, type = {enum, en},
+            occurrence = defaulty, opts = []}]}],
+    ok = enif_protobuf:load_cache(Defs),
+    {enum_with_default, zzz} = enif_protobuf:decode(<<>>, enum_with_default).
+


### PR DESCRIPTION
This diff changes the code for selecting a default enum value to always choose the field assigned to zero. It's not always correct to choose the default field by comparing the `ERL_NIF_TERM`s for the field names because this depends on the order the atoms were first used. This isn't a major change, but should reduce the potential for strange bugs. Thanks!